### PR TITLE
Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(libtermkey)
+
+set(VERSION_MAJOR 0)
+set(VERSION_MINOR 18)
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+find_package(Unibilium REQUIRED)
+include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
+
+include_directories(${PROJECT_BINARY_DIR})
+
+# Generate header termkey.h at configuration time.
+# The t/ directory is a bit of a hack for the include directory, because tests
+# expect to include ../termkey.h, but we are using out of source builds.
+execute_process(
+  COMMAND ${CMAKE_COMMAND}
+  -DINPUT_FILE=${PROJECT_SOURCE_DIR}/termkey.h.in
+  -DOUTPUT_FILE=${PROJECT_BINARY_DIR}/termkey.h.in
+  -P ${PROJECT_SOURCE_DIR}/cmake/convert_in_file.cmake)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/t)
+configure_file(${PROJECT_BINARY_DIR}/termkey.h.in ${PROJECT_BINARY_DIR}/termkey.h @ONLY)
+
+add_definitions(-D _CRT_SECURE_NO_WARNINGS)
+add_definitions(-DHAVE_UNIBILIUM)
+if(NOT MSVC)
+  add_definitions(-std=c99)
+endif()
+
+add_library(termkey termkey.c driver-csi.c driver-ti.c)
+set_target_properties(termkey PROPERTIES PUBLIC_HEADER ${PROJECT_BINARY_DIR}/termkey.h
+	VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+target_link_libraries(termkey ${UNIBILIUM_LIBRARIES})
+
+include(GNUInstallDirs)
+install(TARGETS termkey
+  PUBLIC_HEADER
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+include_directories(${PROJECT_BINARY_DIR}/t)
+enable_testing()
+file(GLOB TESTSOURCES "t/[0-9]*.c")
+foreach(f ${TESTSOURCES})
+  get_filename_component(t ${f} NAME_WE)
+  if(${t} STREQUAL 05read)
+    continue()
+  endif()
+
+  add_executable("test_${t}" ${f} t/taplib.c)
+  target_link_libraries("test_${t}" termkey)
+  add_test("${t}" "test_${t}")
+endforeach()

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ endif
 
 override CFLAGS +=-Wall -std=c99
 
+HAVE_TERMIOS ?= 1
+ifeq ($(HAVE_TERMIOS),1)
+  override CFLAGS += -DHAVE_TERMIOS
+endif
+
 ifeq ($(DEBUG),1)
   override CFLAGS +=-ggdb -DDEBUG
 endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: '{build}'
+install:
+- C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su"
+- C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-x86_64-cmake mingw-w64-x86_64-unibilium"
+build_script:
+  # We cannot have sh.exe in the PATH (MinGW)
+- set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+  # Ignore msys path
+- set PATH=C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
+  # Fixes issues with some toolchains where cc is called instead of gcc
+- set CC=gcc
+- mkdir build
+- cd build
+- cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+- mingw32-make VERBOSE=1

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -1,0 +1,47 @@
+# - Try to find unibilium
+# Once done this will define
+#  UNIBILIUM_FOUND - System has unibilium
+#  UNIBILIUM_INCLUDE_DIRS - The unibilium include directories
+#  UNIBILIUM_LIBRARIES - The libraries needed to use unibilium
+
+if(NOT UNIBILIUM_USE_BUNDLED)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_UNIBILIUM QUIET unibilium)
+  endif()
+else()
+  set(PC_UNIBILIUM_INCLUDEDIR)
+  set(PC_UNIBILIUM_INCLUDE_DIRS)
+  set(PC_UNIBILIUM_LIBDIR)
+  set(PC_UNIBILIUM_LIBRARY_DIRS)
+  set(LIMIT_SEARCH NO_DEFAULT_PATH)
+endif()
+
+set(UNIBILIUM_DEFINITIONS ${PC_UNIBILIUM_CFLAGS_OTHER})
+
+find_path(UNIBILIUM_INCLUDE_DIR unibilium.h
+          PATHS ${PC_UNIBILIUM_INCLUDEDIR} ${PC_UNIBILIUM_INCLUDE_DIRS}
+          ${LIMIT_SEARCH})
+
+# If we're asked to use static linkage, add libunibilium.a as a preferred library name.
+if(UNIBILIUM_USE_STATIC)
+  list(APPEND UNIBILIUM_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}unibilium${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+list(APPEND UNIBILIUM_NAMES unibilium)
+
+find_library(UNIBILIUM_LIBRARY NAMES ${UNIBILIUM_NAMES}
+  HINTS ${PC_UNIBILIUM_LIBDIR} ${PC_UNIBILIUM_LIBRARY_DIRS}
+  ${LIMIT_SEARCH})
+
+set(UNIBILIUM_LIBRARIES ${UNIBILIUM_LIBRARY})
+set(UNIBILIUM_INCLUDE_DIRS ${UNIBILIUM_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set UNIBILIUM_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(unibilium DEFAULT_MSG
+  UNIBILIUM_LIBRARY UNIBILIUM_INCLUDE_DIR)
+
+mark_as_advanced(UNIBILIUM_INCLUDE_DIR UNIBILIUM_LIBRARY)

--- a/cmake/convert_in_file.cmake
+++ b/cmake/convert_in_file.cmake
@@ -1,0 +1,6 @@
+# Convert .in files with @@VARIABLE@@ expressions into @VARIABLE@
+
+message(STATUS "Processing ${INPUT_FILE}")
+file(READ ${INPUT_FILE} CONTENT_IN)
+string(REGEX REPLACE "@@" "@" CONTENT_OUT "${CONTENT_IN}")
+file(WRITE ${OUTPUT_FILE} "${CONTENT_OUT}")

--- a/driver-ti.c
+++ b/driver-ti.c
@@ -17,7 +17,9 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#ifndef _WIN32
+# include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -338,8 +340,10 @@ static int start_driver(TermKey *tk, void *info)
   if(fstat(tk->fd, &statbuf) == -1)
     return 0;
 
+#ifndef _WIN32
   if(S_ISFIFO(statbuf.st_mode))
     return 1;
+#endif
 
   // Can't call putp or tputs because they suck and don't give us fd control
   len = strlen(start_string);
@@ -367,8 +371,10 @@ static int stop_driver(TermKey *tk, void *info)
   if(fstat(tk->fd, &statbuf) == -1)
     return 0;
 
+#ifndef _WIN32
   if(S_ISFIFO(statbuf.st_mode))
     return 1;
+#endif
 
   /* The terminfo database will contain keys in application cursor key mode.
    * We may need to enable that mode

--- a/termkey-internal.h
+++ b/termkey-internal.h
@@ -4,7 +4,14 @@
 #include "termkey.h"
 
 #include <stdint.h>
-#include <termios.h>
+#ifdef HAVE_TERMIOS
+# include <termios.h>
+#endif
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 struct TermKeyDriver
 {
@@ -41,8 +48,10 @@ struct TermKey {
   size_t hightide; /* Position beyond buffstart at which peekkey() should next start
                     * normally 0, but see also termkey_interpret_csi */
 
+#ifdef HAVE_TERMIOS
   struct termios restore_termios;
   char restore_termios_valid;
+#endif
 
   TermKey_Terminfo_Getstr_Hook *ti_getstr_hook;
   void *ti_getstr_hook_data;

--- a/termkey.c
+++ b/termkey.c
@@ -3,14 +3,20 @@
 
 #include <ctype.h>
 #include <errno.h>
-#include <poll.h>
-#include <unistd.h>
+#ifndef _WIN32
+# include <poll.h>
+# include <unistd.h>
+# include <strings.h>
+#endif
 #include <string.h>
-#include <strings.h>
 
 #include <stdio.h>
 
-#define strcaseeq(a,b) (strcasecmp(a,b) == 0)
+#ifdef _MSC_VER
+# define strcaseeq(a,b) (_stricmp(a,b) == 0)
+#else
+# define strcaseeq(a,b) (strcasecmp(a,b) == 0)
+#endif
 
 void termkey_check_version(int major, int minor)
 {
@@ -282,7 +288,9 @@ static TermKey *termkey_alloc(void)
   tk->buffsize  = 256; /* bytes */
   tk->hightide  = 0;
 
+#ifdef HAVE_TERMIOS
   tk->restore_termios_valid = 0;
+#endif
 
   tk->ti_getstr_hook = NULL;
   tk->ti_getstr_hook_data = NULL;
@@ -483,6 +491,7 @@ int termkey_start(TermKey *tk)
   if(tk->is_started)
     return 1;
 
+#ifdef HAVE_TERMIOS
   if(tk->fd != -1 && !(tk->flags & TERMKEY_FLAG_NOTERMIOS)) {
     struct termios termios;
     if(tcgetattr(tk->fd, &termios) == 0) {
@@ -517,6 +526,7 @@ int termkey_start(TermKey *tk)
       tcsetattr(tk->fd, TCSANOW, &termios);
     }
   }
+#endif
 
   struct TermKeyDriverNode *p;
   for(p = tk->drivers; p; p = p->next)
@@ -542,8 +552,10 @@ int termkey_stop(TermKey *tk)
     if(p->driver->stop_driver)
       (*p->driver->stop_driver)(tk, p->info);
 
+#ifdef HAVE_TERMIOS
   if(tk->restore_termios_valid)
     tcsetattr(tk->fd, TCSANOW, &tk->restore_termios);
+#endif
 
   tk->is_started = 0;
 
@@ -1046,6 +1058,7 @@ TermKeyResult termkey_getkey_force(TermKey *tk, TermKeyKey *key)
   return ret;
 }
 
+#ifndef _WIN32
 TermKeyResult termkey_waitkey(TermKey *tk, TermKeyKey *key)
 {
   if(tk->fd == -1) {
@@ -1105,6 +1118,7 @@ retry:
 
   /* UNREACHABLE */
 }
+#endif
 
 TermKeyResult termkey_advisereadable(TermKey *tk)
 {

--- a/termkey.h.in
+++ b/termkey.h.in
@@ -197,7 +197,9 @@ void termkey_canonicalise(TermKey *tk, TermKeyKey *key);
 
 TermKeyResult termkey_getkey(TermKey *tk, TermKeyKey *key);
 TermKeyResult termkey_getkey_force(TermKey *tk, TermKeyKey *key);
+#ifndef _WIN32
 TermKeyResult termkey_waitkey(TermKey *tk, TermKeyKey *key);
+#endif
 
 TermKeyResult termkey_advisereadable(TermKey *tk);
 


### PR DESCRIPTION
Splitting up the code from the cmake recipe

- [x] added HAVE_TERMIOS to enable disable the use of termios.h
